### PR TITLE
Fix ta-lib build error instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Third version (first public version) of a personal algorithmic SOLANA trading re
 ## Getting started
 1. Install Python 3.10
 2. In a terminal, execute `pip install -r requirements.txt`
+   - If the build for **ta-lib** fails, install a pre-built wheel from the [TA‑Lib release page](https://github.com/mrjbq7/ta-lib/releases) that matches your Python version, e.g.:
+     ```bash
+     pip install https://github.com/mrjbq7/ta-lib/releases/download/0.4.0/TA_Lib-0.4.0-cp310-cp310-manylinux_2_17_x86_64.whl
+     ```
 3. Run the code in the root folder using `python app.py`
 4. Access your interface at `127.0.0.1:5000`
 


### PR DESCRIPTION
## Summary
- add troubleshooting note about installing the `ta-lib` pre-built wheel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598d6feec08323b4953f6d9d4036e9