### PR TITLE
Fix TA-Lib path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Third version (first public version) of a personal algorithmic SOLANA trading re
    - **Linux** – compile from source
      ```bash
      wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
-     tar -xzf ta-lib-0.4.0-src.tar.gz && cd ta-lib
-     ./configure --prefix=/usr && make
-     sudo make install
-     cd ..
+    tar -xzf ta-lib-0.4.0-src.tar.gz && cd ta-lib
+    ./configure --prefix=/usr && make
+    sudo make install
+    sudo ldconfig
+    export TA_LIBRARY_PATH=/usr/lib
+    export TA_INCLUDE_PATH=/usr/include
+    cd ..
      ```
    - **Windows** – download and run the installer from [ta-lib.org](https://ta-lib.org/install/)
 3. After the library is installed, execute `pip install -r requirements.txt`


### PR DESCRIPTION
## Summary
- document how to export TA-Lib library and include paths on Linux

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a26ef1d8832384dce97c0ffd2d3d